### PR TITLE
set the parent state to connected if in open.

### DIFF
--- a/any-db/lib/transaction.js
+++ b/any-db/lib/transaction.js
@@ -84,6 +84,9 @@ Transaction.prototype._createChildTransaction = function (callback) {
     rollback:     'ROLLBACK TO ' + savepointName
   })
 
+  if (this.state() == 'open')
+    this.state('connected')
+
   tx.on('query', this.emit.bind(this, 'query'))
     .once('connected', this.state.bind(this, 'connected'))
     .once('close',  this._runQueue.bind(this))


### PR DESCRIPTION
When opening a nested transaction when the parent is in state `open` I get the following error:

```
TypeError: Cannot call method 'bind' of undefined
    at OpenTransaction.Transaction._createChildTransaction (node_modules/any-db/lib/transaction.js:92:36)
    at OpenTransaction.begin (node_modules/any-db/lib/transaction.js:242:15)
```
