### PR TITLE
Fix ConnectionPool.query function to behave exactly like Connection.query

### DIFF
--- a/any-db-pool/index.js
+++ b/any-db-pool/index.js
@@ -50,7 +50,15 @@ ConnectionPool.prototype.query = function (statement, params, callback) {
     , query = this._adapter.createQuery(statement, params, callback)
 
   this.acquire(function (err, conn) {
-    if (err) return callback ? callback(err) : query.emit('error', err)
+    if (err) {
+      if (typeof params === 'function') {
+        return params(err)
+      } else if (callback) {
+        return callback(err);
+      } else {
+        return query.emit('error', err);
+      }
+    }
     conn.query(query);
     self.emit('query', query)
     var release = once(self.release.bind(self, conn))

--- a/test/pool_error.test.js
+++ b/test/pool_error.test.js
@@ -1,0 +1,12 @@
+
+require('./helpers').allErrorPools("Pool query error handling", function (pool, t) {
+  t.plan(2);
+  pool.query('', function(err) {
+    t.assert(err, "Error should be defined")
+  });
+  pool.query('', [], function(err) {
+    t.assert(err, "Error should be defined")
+  });
+});
+
+


### PR DESCRIPTION
The second argument of Connection.query could be either a function
(callback) or a list of values. The ConnectionPool.query should not
assume that the third argument to be the callback function
